### PR TITLE
fix(instrumentation): follow semantic conventions

### DIFF
--- a/src/instrumentation/express.js
+++ b/src/instrumentation/express.js
@@ -25,15 +25,18 @@ function patch (express, tracers) {
     const url = `${req.protocol}://${req.hostname}${req.originalUrl}`
     const parentSpanContexts = tracers.map((tracer) => tracer.extract(FORMAT_HTTP_HEADERS, req.headers))
     const spans = parentSpanContexts.map((parentSpanContext, key) =>
-      cls.startRootSpan(tracers[key], OPERATION_NAME, { childOf: parentSpanContext }))
+      cls.startRootSpan(tracers[key], OPERATION_NAME, {
+        childOf: parentSpanContext,
+        tags: {
+          [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_SERVER,
+          [Tags.HTTP_URL]: url,
+          [Tags.HTTP_METHOD]: req.method
+        }
+      }))
     debug(`Operation started ${OPERATION_NAME}`, {
       [Tags.HTTP_URL]: url,
       [Tags.HTTP_METHOD]: req.method
     })
-
-    spans.forEach((span) => span.setTag(Tags.HTTP_URL, url))
-    spans.forEach((span) => span.setTag(Tags.HTTP_METHOD, req.method))
-    spans.forEach((span) => span.setTag(Tags.SPAN_KIND_RPC_SERVER, true))
 
     if (req.connection.remoteAddress) {
       spans.forEach((span) => span.log({ peerRemoteAddress: req.connection.remoteAddress }))

--- a/src/instrumentation/expressError.spec.js
+++ b/src/instrumentation/expressError.spec.js
@@ -50,10 +50,13 @@ describe('instrumentation: expressError', () => {
         .expect(500)
         .end()
 
-      expect(cls.startChildSpan).to.be.calledWith(tracer, instrumentation.OPERATION_NAME)
+      expect(cls.startChildSpan).to.be.calledWith(tracer, instrumentation.OPERATION_NAME, {
+        tags: {
+          [Tags.ERROR]: true
+        }
+      })
 
       expect(mockRootSpan.setTag).to.be.calledWith(Tags.ERROR, true)
-      expect(mockChildSpan.setTag).to.be.calledWith(Tags.ERROR, true)
       expect(mockChildSpan.log).to.be.calledWith({
         event: 'error',
         'error.object': err,
@@ -79,10 +82,13 @@ describe('instrumentation: expressError', () => {
         .expect(500)
         .end()
 
-      expect(cls.startChildSpan).to.be.calledWith(tracer, instrumentation.OPERATION_NAME)
+      expect(cls.startChildSpan).to.be.calledWith(tracer, instrumentation.OPERATION_NAME, {
+        tags: {
+          [Tags.ERROR]: true
+        }
+      })
 
       expect(mockRootSpan.setTag).to.be.calledWith(Tags.ERROR, true)
-      expect(mockChildSpan.setTag).to.be.calledWith(Tags.ERROR, true)
       expect(mockChildSpan.log).to.be.calledWith({
         event: 'error',
         'error.object': err,

--- a/src/instrumentation/httpClient.spec.js
+++ b/src/instrumentation/httpClient.spec.js
@@ -43,10 +43,13 @@ describe('instrumentation: httpClient', () => {
 
       await request('http://risingstack.com')
 
-      expect(cls.startChildSpan).to.be.calledWith(tracer, instrumentation.OPERATION_NAME)
-      expect(mockChildSpan.setTag).to.have.calledWith(Tags.HTTP_URL, 'http://risingstack.com:80')
-      expect(mockChildSpan.setTag).to.have.calledWith(Tags.HTTP_METHOD, 'GET')
-      expect(mockChildSpan.setTag).to.have.calledWith(Tags.SPAN_KIND_RPC_CLIENT, true)
+      expect(cls.startChildSpan).to.be.calledWith(tracer, instrumentation.OPERATION_NAME, {
+        tags: {
+          [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_CLIENT,
+          [Tags.HTTP_URL]: 'http://risingstack.com:80',
+          [Tags.HTTP_METHOD]: 'GET'
+        }
+      })
       expect(mockChildSpan.setTag).to.have.calledWith(Tags.HTTP_STATUS_CODE, 200)
       expect(mockChildSpan.finish).to.have.callCount(1)
     })
@@ -68,10 +71,13 @@ describe('instrumentation: httpClient', () => {
 
       await request('https://risingstack.com')
 
-      expect(cls.startChildSpan).to.be.calledWith(tracer, instrumentation.OPERATION_NAME)
-      expect(mockChildSpan.setTag).to.have.calledWith(Tags.HTTP_URL, 'https://risingstack.com:443')
-      expect(mockChildSpan.setTag).to.have.calledWith(Tags.HTTP_METHOD, 'GET')
-      expect(mockChildSpan.setTag).to.have.calledWith(Tags.SPAN_KIND_RPC_CLIENT, true)
+      expect(cls.startChildSpan).to.be.calledWith(tracer, instrumentation.OPERATION_NAME, {
+        tags: {
+          [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_CLIENT,
+          [Tags.HTTP_URL]: 'https://risingstack.com:443',
+          [Tags.HTTP_METHOD]: 'GET'
+        }
+      })
       expect(mockChildSpan.setTag).to.have.calledWith(Tags.HTTP_STATUS_CODE, 200)
       expect(mockChildSpan.finish).to.have.callCount(1)
     })

--- a/src/instrumentation/mongodbCore.spec.js
+++ b/src/instrumentation/mongodbCore.spec.js
@@ -43,9 +43,14 @@ describe('instrumentation: mongodb-core', () => {
 
       expect(result).to.be.eql(site)
 
-      expect(cls.startChildSpan).to.be.calledWith(tracer, `${instrumentation.OPERATION_NAME}_insert`)
-      expect(mockChildSpan.setTag).to.have.calledWith(Tags.DB_TYPE, instrumentation.DB_TYPE)
-      expect(mockChildSpan.setTag).to.have.calledWith(Tags.DB_STATEMENT, JSON.stringify([site]))
+      expect(cls.startChildSpan).to.be.calledWith(tracer, `${instrumentation.OPERATION_NAME}_insert`, {
+        tags: {
+          [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_CLIENT,
+          [Tags.DB_TYPE]: instrumentation.DB_TYPE,
+          [Tags.DB_STATEMENT]: JSON.stringify([site]),
+          [Tags.DB_INSTANCE]: 'mydb.sites'
+        }
+      })
       expect(mockChildSpan.finish).to.have.callCount(1)
     })
 

--- a/src/instrumentation/mysql.spec.js
+++ b/src/instrumentation/mysql.spec.js
@@ -41,9 +41,13 @@ describe('instrumentation: mysql', () => {
 
       expect(result[0]).to.be.eql([{ result: 1 }])
 
-      expect(cls.startChildSpan).to.be.calledWith(tracer, `${instrumentation.OPERATION_NAME}_query`)
-      expect(mockChildSpan.setTag).to.have.calledWith(Tags.DB_TYPE, instrumentation.DB_TYPE)
-      expect(mockChildSpan.setTag).to.have.calledWith(Tags.DB_STATEMENT, query)
+      expect(cls.startChildSpan).to.be.calledWith(tracer, `${instrumentation.OPERATION_NAME}_query`, {
+        tags: {
+          [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_CLIENT,
+          [Tags.DB_TYPE]: instrumentation.DB_TYPE,
+          [Tags.DB_STATEMENT]: query
+        }
+      })
 
       // FIXME: only with ../instrument.js tests together
       // expect(mockChildSpan.finish).to.have.callCount(1)

--- a/src/instrumentation/pg.js
+++ b/src/instrumentation/pg.js
@@ -23,15 +23,18 @@ function patch (pg, tracers) {
       }
 
       const operationName = `${OPERATION_NAME}_query`
-      const spans = tracers.map((tracer) => cls.startChildSpan(tracer, operationName))
+      const spans = tracers.map((tracer) => cls.startChildSpan(tracer, operationName, {
+        tags: {
+          [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_CLIENT,
+          [Tags.DB_TYPE]: DB_TYPE,
+          [Tags.DB_STATEMENT]: statement
+        }
+      }))
 
       debug(`Operation started ${operationName}`, {
         [Tags.DB_TYPE]: DB_TYPE,
         [Tags.DB_STATEMENT]: statement
       })
-
-      spans.forEach((span) => span.setTag(Tags.DB_TYPE, DB_TYPE))
-      spans.forEach((span) => span.setTag(Tags.DB_STATEMENT, statement))
 
       pgQuery.callback = (err, res) => {
         if (err) {

--- a/src/instrumentation/pg.spec.js
+++ b/src/instrumentation/pg.spec.js
@@ -41,9 +41,13 @@ describe('instrumentation: pg', () => {
 
       expect(rows).to.be.eql([{ result: 1 }])
 
-      expect(cls.startChildSpan).to.be.calledWith(tracer, `${instrumentation.OPERATION_NAME}_query`)
-      expect(mockChildSpan.setTag).to.have.calledWith(Tags.DB_TYPE, instrumentation.DB_TYPE)
-      expect(mockChildSpan.setTag).to.have.calledWith(Tags.DB_STATEMENT, query)
+      expect(cls.startChildSpan).to.be.calledWith(tracer, `${instrumentation.OPERATION_NAME}_query`, {
+        tags: {
+          [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_CLIENT,
+          [Tags.DB_TYPE]: instrumentation.DB_TYPE,
+          [Tags.DB_STATEMENT]: query
+        }
+      })
 
       // FIXME: only with ../instrument.js tests together
       // expect(mockChildSpan.finish).to.have.callCount(1)

--- a/src/instrumentation/redis.spec.js
+++ b/src/instrumentation/redis.spec.js
@@ -35,9 +35,13 @@ describe('instrumentation: redis', () => {
     it('should start and finish span', (done) => {
       client.set('string key', 'string val', (err, replies) => {
         expect(replies).to.be.eql('OK')
-        expect(cls.startChildSpan).to.be.calledWith(tracer, 'redis_set')
-        expect(mockChildSpan.setTag).to.have.calledWith(Tags.DB_TYPE, 'redis')
-        expect(mockChildSpan.setTag).to.have.calledWith(Tags.DB_STATEMENT, 'set string key,string val')
+        expect(cls.startChildSpan).to.be.calledWith(tracer, 'redis_set', {
+          tags: {
+            [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_CLIENT,
+            [Tags.DB_TYPE]: instrumentation.DB_TYPE,
+            [Tags.DB_STATEMENT]: 'set string key,string val'
+          }
+        })
 
         // FIXME: is this an issue?
         // expect(mockChildSpan.finish).to.have.callCount(1)

--- a/src/instrumentation/restify.js
+++ b/src/instrumentation/restify.js
@@ -21,16 +21,19 @@ function patch (restify, tracers) {
     // start
     const parentSpanContexts = tracers.map((tracer) => tracer.extract(FORMAT_HTTP_HEADERS, req.headers))
     const spans = parentSpanContexts.map((parentSpanContext, key) =>
-      cls.startRootSpan(tracers[key], OPERATION_NAME, { childOf: parentSpanContext }))
+      cls.startRootSpan(tracers[key], OPERATION_NAME, {
+        childOf: parentSpanContext,
+        tags: {
+          [Tags.SPAN_KIND]: Tags.SPAN_KIND_RPC_SERVER,
+          [Tags.HTTP_URL]: req.url,
+          [Tags.HTTP_METHOD]: req.method
+        }
+      }))
 
     debug(`Operation started ${OPERATION_NAME}`, {
       [Tags.HTTP_URL]: req.url,
       [Tags.HTTP_METHOD]: req.method
     })
-
-    spans.forEach((span) => span.setTag(Tags.HTTP_URL, req.url))
-    spans.forEach((span) => span.setTag(Tags.HTTP_METHOD, req.method))
-    spans.forEach((span) => span.setTag(Tags.SPAN_KIND_RPC_SERVER, true))
 
     if (req.connection.remoteAddress) {
       spans.forEach((span) => span.log({ peerRemoteAddress: req.connection.remoteAddress }))


### PR DESCRIPTION
Follow: https://github.com/opentracing/specification/blob/master/semantic_conventions.md

- set initial tags at `startSpan`
- set `rpc.kind`