### PR TITLE
Set redis version to 2.8

### DIFF
--- a/src/instrumentation/redis.js
+++ b/src/instrumentation/redis.js
@@ -90,7 +90,7 @@ function unpatch (redis) {
 module.exports = {
   name: 'redis',
   module: 'redis',
-  supportedVersions: ['2.4'],
+  supportedVersions: ['2.8'],
   OPERATION_NAME,
   DB_TYPE,
   patch,


### PR DESCRIPTION
Hey there,

I've run into some issues with the Redis instrumentation. I've tested with Redis 2.4.2 as the supported versions below used to specify 2.4. However for some reason, redis didn't get patched at all. I have not further investigated why, but when testing with Redis 2.8 it seems to work flawlessly. I can see, you've also specified 2.8 in the package dependencies, so I'd suggest bumping the supported version to 2.8.