### PR TITLE
Instrument#hookModule to manually hook module

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,37 @@ const express = require('express')
 // ...
 ```
 
+This package depends
+on [require-in-the-middle](https://github.com/opbeat/require-in-the-middle)
+and [shimmer](https://www.npmjs.com/package/shimmer) to monkeypatch tracing
+information onto the modules [listed below](#Instrumentations). Therefore it is
+crucial that you require() supported modules after creating the tracing
+instrument.
+
+If you are using node 8.5+'s experimental module support, you will need to
+manually hook supported modules:
+
+```
+import Instrument from '@risingstack/opentracing-auto';
+import jaeger from 'jaeger-client';
+import UDPSender from 'jaeger-client/dist/src/reporters/udp_sender';
+import http from 'http';
+
+const instrument = new Instrument({
+  tracers: [
+    new jaeger.Tracer(
+      'my-service-name',
+      new jaeger.RemoteReporter(new UDPSender.default({ host: 'my-jaeger-host' })),
+      new jaeger.RateLimitingSampler(1),
+      {}
+    ),
+  ],
+});
+
+instrument.hookModule(http, 'http');
+
+```
+
 ## API
 
 ### new Instrument({ tracers: [tracer1, tracer2] })

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -45,6 +45,21 @@ class Instrument {
 
     // Instrunent modules: hook require
     hook(instrumentedModules, (moduleExports, moduleName, moduleBaseDir) => {
+      this.hookModule(moduleExports, moduleName, moduleBaseDir)
+    })
+
+    debug('Patched')
+  }
+
+  /**
+  * Manually hook a module, useful when require-in-the-middle does not work,
+  * such as when you are using ESM.
+  * @method hookModule
+  * @param {Object} module
+  * @param {string} moduleName
+  * @param {string} moduleBaseDir
+  */
+  hookModule(moduleExports, moduleName, moduleBaseDir) {
       let moduleVersion
 
       // Look for version in package.json
@@ -77,9 +92,6 @@ class Instrument {
         })
 
       return moduleExports
-    })
-
-    debug('Patched')
   }
 
   /**

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -45,7 +45,7 @@ class Instrument {
 
     // Instrunent modules: hook require
     hook(instrumentedModules, (moduleExports, moduleName, moduleBaseDir) => {
-      this.hookModule(moduleExports, moduleName, moduleBaseDir)
+      return this.hookModule(moduleExports, moduleName, moduleBaseDir)
     })
 
     debug('Patched')


### PR DESCRIPTION
When using Node 8.5 or greater with --experimental-modules,
require-in-the-middle doesn't work because we don't use require, we use import.

Add Instrument#hookModule to allow you to manually hook a module